### PR TITLE
fix SPDX identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "keywords": ["contao", "theme", "content", "layout", "elements"],
   "type": "contao-bundle",
   "homepage": "https://github.com/srhinow/themecontent-bundle",
-  "license": "GPL-3.0+",
+  "license": "GPL-3.0-or-later",
   "authors":[
     {
       "name":"Sven Rhinow",


### PR DESCRIPTION
`GPL-3.0+` is not a valid SPDX identifier